### PR TITLE
Rebrand from GT Research Finder, to Research Finder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
-# gt-research-finder-org
- Research Finder for all GT students!
+# research-finder.org
+
+### 🔬 Connecting Students with Professors & PhD Mentors
+**Research Finder** is a one-stop platform designed to bridge the gap between students and academic research opportunities. Our goal is to revolutionize the way students discover and apply for research positions in universities worldwide.
+
+---
+
+## 🎯 Our Vision
+🔹 **A LinkedIn for Academic Research** — Unlike industry job portals, we focus **exclusively on academic research** positions within university labs and research groups.
+
+🔹 **Student-Centric Profiles** — Students can create **detailed research profiles**, showcasing their skills, experience, and areas of interest.
+
+🔹 **Verified Faculty & PhDs** — Professors and PhDs can create verified profiles to **list open research positions** in their labs.
+
+🔹 **Smart AI Matching** — Our AI-powered system ensures that **students and faculty are matched** based on research interests, skills, and preferences.
+
+🔹 **Flexible Research Opportunities** — Faculty can specify:
+   - 💰 **Paid or Unpaid** positions
+   - 🌍 **Open to students outside their institution**
+   - 📚 **Areas of research and expertise**
+
+---
+
+## 🚀 Progress So Far
+✅ **Landing Page** is live  
+✅ **Waitlist Registration** is open for students 
+
+🔜 Next steps:
+- Faculty onboarding
+- AI-driven research match implementation
+
+---
+
+## ⚙️ Tech Stack
+🖥️ **Frontend:** Next.js + Tailwind CSS  
+🗄️ **Backend:** Supabase  
+
+---
+
+## 👥 Founders
+**Jeet Hirenkumar Dekivadia** & **Showmick Das**
+
+🌐 *Join the waitlist & stay updated:* [reseearch-finder.org](https://reseearch-finder.org)
+
+---
+🚀 *Empowering the next generation of researchers!*

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -6,7 +6,7 @@ export default function JoinPage() {
     <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-b from-gt-navy to-black">
       <h1 className="text-4xl md:text-6xl font-display font-bold mb-12 text-center">
         <span className="bg-clip-text text-transparent bg-gradient-to-r from-gt-gold via-gt-gold-light to-white">
-          Join the GT Research Community
+          Join the Global Academic Research Community
         </span>
       </h1>
       <div className="flex flex-col md:flex-row gap-8">

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -6,7 +6,7 @@ export default function JoinPage() {
     <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-b from-gt-navy to-black">
       <h1 className="text-4xl md:text-6xl font-display font-bold mb-12 text-center">
         <span className="bg-clip-text text-transparent bg-gradient-to-r from-gt-gold via-gt-gold-light to-white">
-          Join the Global Academic Research Community
+          Join the Academic Research Community
         </span>
       </h1>
       <div className="flex flex-col md:flex-row gap-8">

--- a/app/join/professor/page.tsx
+++ b/app/join/professor/page.tsx
@@ -60,7 +60,7 @@ export default function ProfessorJoinPage() {
         </div>
         <div>
           <label htmlFor="expertise" className="block text-gt-gold mb-2">
-            Area of Expertise
+            Areas of Expertise
           </label>
           <input
             type="text"

--- a/app/join/professor/page.tsx
+++ b/app/join/professor/page.tsx
@@ -37,7 +37,7 @@ export default function ProfessorJoinPage() {
         </div>
         <div>
           <label htmlFor="email" className="block text-gt-gold mb-2">
-            Georgia Tech Email
+            Institute Email
           </label>
           <input
             type="email"

--- a/app/join/student/page.tsx
+++ b/app/join/student/page.tsx
@@ -37,7 +37,7 @@ export default function StudentJoinPage() {
         </div>
         <div>
           <label htmlFor="email" className="block text-gt-gold mb-2">
-            Georgia Tech Email
+            Institute Email
           </label>
           <input
             type="email"
@@ -49,7 +49,7 @@ export default function StudentJoinPage() {
         </div>
         <div>
           <label htmlFor="qualification" className="block text-gt-gold mb-2">
-            Qualification
+            Qualifications
           </label>
           <input
             type="text"
@@ -60,7 +60,7 @@ export default function StudentJoinPage() {
         </div>
         <div>
           <label htmlFor="interest" className="block text-gt-gold mb-2">
-            Area of Interest
+            Areas of Interest
           </label>
           <input
             type="text"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,8 +14,8 @@ const spaceGrotesk = Space_Grotesk({
 })
 
 export const metadata: Metadata = {
-  title: "GT Research Finder",
-  description: "Find research opportunities at Georgia Tech",
+  title: "Research Finder",
+  description: "Discover and apply for academic research opportunities at institutes around the world",
 }
 
 export default function RootLayout({

--- a/components/Benefits.tsx
+++ b/components/Benefits.tsx
@@ -23,7 +23,7 @@ const benefits = [
   {
     icon: CheckCircle,
     title: "Verified Positions",
-    description: "All research opportunities are verified and directly posted by Georgia Tech faculty members.",
+    description: "All research opportunities are verified and directly posted by University faculty members.",
   },
 ]
 
@@ -47,11 +47,11 @@ export default function Benefits() {
         >
           <h2 className="text-4xl md:text-5xl font-condensed font-bold mb-6">
             <span className="bg-clip-text text-transparent bg-gradient-to-r from-gt-gold via-gt-gold-light to-white">
-              Benefits for GT Students
+              Benefits for Students
             </span>
           </h2>
           <p className="text-xl text-gray-300 font-slab max-w-3xl mx-auto">
-            Experience a revolutionary way to discover and apply for research opportunities at Georgia Tech
+            Experience a revolutionary way to discover and apply for research opportunities
           </p>
         </motion.div>
 

--- a/components/FAQ.tsx
+++ b/components/FAQ.tsx
@@ -6,9 +6,9 @@ import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/
 
 const faqs = [
   {
-    question: "Who can use GT Research Finder?",
+    question: "Who can use Research Finder?",
     answer:
-      "GT Research Finder is available to all current Georgia Tech students looking for research opportunities across various departments and labs.",
+      "Research Finder is available to all current students looking for research opportunities across various departments and labs.",
   },
   {
     question: "How does the AI matching system work?",
@@ -24,11 +24,6 @@ const faqs = [
     question: "Can professors post research opportunities?",
     answer:
       "Yes! Professors can create accounts to post positions and review applications directly through our platform.",
-  },
-  {
-    question: "Is this an official Georgia Tech platform?",
-    answer:
-      "While we're created by GT students for GT students, we're an independent platform working closely with the GT community.",
   },
 ]
 

--- a/components/Features.tsx
+++ b/components/Features.tsx
@@ -47,7 +47,7 @@ export default function Features() {
           transition={{ duration: 0.8 }}
         >
           <h2 className="text-4xl md:text-5xl font-condensed font-bold mb-6 bg-clip-text text-transparent bg-gradient-to-r from-gt-gold via-gt-gold-light to-white">
-            Why Choose GT Research Finder?
+            Why Choose Research Finder?
           </h2>
           <p className="text-xl text-gray-300 font-slab max-w-3xl mx-auto">
             Our platform streamlines the research discovery process, making it easier than ever to find your perfect

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -9,8 +9,8 @@ export default function Footer() {
       <div className="container mx-auto px-4">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           <div className="space-y-4">
-            <h3 className="text-xl font-display font-bold text-gt-gold">GT Research Finder</h3>
-            <p className="text-gray-400">Connecting GT students with research opportunities.</p>
+            <h3 className="text-xl font-display font-bold text-gt-gold">Research Finder</h3>
+            <p className="text-gray-400">Connecting students with research opportunities.</p>
           </div>
 
           <div>
@@ -88,7 +88,7 @@ export default function Footer() {
 
         <div className="mt-12 pt-8 border-t border-gray-800">
           <p className="text-center text-gray-400">
-            © {new Date().getFullYear()} GT Research Finder. All rights reserved.
+            © {new Date().getFullYear()} Research Finder. All rights reserved.
           </p>
         </div>
       </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -29,7 +29,7 @@ const Header = () => {
     >
       <div className="container mx-auto px-4 py-4 flex justify-between items-center">
         <motion.div className="text-2xl font-bold" whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
-          GT Research Finder
+          Research Finder
         </motion.div>
         <nav className="hidden md:flex space-x-6">
           <NavLink href="#features">Features</NavLink>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -103,7 +103,7 @@ export default function Hero() {
                 whileHover={{ scale: 1.05 }}
                 transition={{ type: "spring", stiffness: 300, damping: 10 }}
               >
-                GT Research Finder
+                Research Finder
               </motion.span>
             </motion.h1>
 
@@ -113,9 +113,7 @@ export default function Hero() {
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.8, delay: 0.4 }}
             >
-              Connect with Georgia Tech's leading researchers and labs
-              <br />
-              through our AI-powered platform
+              Connect with leading researchers and labs through our AI-powered platform
             </motion.p>
 
             {/* Updated CTA Button */}

--- a/components/HowItWorks.tsx
+++ b/components/HowItWorks.tsx
@@ -8,7 +8,7 @@ const steps = [
   {
     icon: UserPlus,
     title: "Create Your Profile",
-    description: "Sign up with your GT credentials and build your academic profile with your interests and skills.",
+    description: "Sign up with your institute credentials and build your academic profile with your interests and skills.",
   },
   {
     icon: Search,

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "1.0.4",
-    "date-fns": "4.1.0",
+    "date-fns": "3.6.0",
     "embla-carousel-react": "8.5.1",
     "input-otp": "1.4.1",
     "lucide-react": "^0.454.0",


### PR DESCRIPTION
Removed all mentions of GT, and transformed the frontend to make it open to students and faculty of all universities.